### PR TITLE
Fixes exam pools not closing properly

### DIFF
--- a/observers/observers.py
+++ b/observers/observers.py
@@ -16,7 +16,7 @@ class AnalyticsObserver(BaseObserver):
 
     def __init__(self, client, pool, **options) -> None:
         super().__init__()
-        self.name = 'Pool Analytics'
+        self.name = pool.id
         self.client = client
         self.operation = None
         self.pool = pool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.11+cpu
+torch==1.11.0
 crowd_kit==1.0.0
 pandas==1.4.1
 pytest==7.1.0


### PR DESCRIPTION
`AnalyticsObserver`s are now given unique names (and consequently unique `unique_key`s)