### PR TITLE
Remove support for manual CAPTCHA

### DIFF
--- a/examples/config/classify_text_gold.yaml
+++ b/examples/config/classify_text_gold.yaml
@@ -14,13 +14,11 @@ options:
 interface:
   prompt: Read the text and assign it to the most appropriate category.
 project:
-  # id: 129368
   setup:
     public_name: Classify text into categories
     public_description: Read the text and assign it to the most appropriate category.
   instructions: instructions/classify_text_instructions.html
 pool:
-  # id: 1387049
   estimated_time_per_suite: 60
   setup:
     private_name: Classify text

--- a/src/abulafia/task_specs/core_task.py
+++ b/src/abulafia/task_specs/core_task.py
@@ -802,35 +802,6 @@ class CrowdsourcingTask:
                             action=toloka.actions.ChangeOverlap(delta=1, open_pool=True)
                         )
 
-                # Set up captcha quality control
-                if 'captcha' in self.qual_conf:
-
-                    # Unpack rules into variables 
-                    freq = self.qual_conf['captcha']['frequency'].upper()
-                    success_rate = self.qual_conf['captcha']['success_rate']
-                    duration = self.qual_conf['captcha']['ban_duration']
-                    units = self.qual_conf['captcha']['ban_units'].upper()
-
-                    # Set captcha frequency according to configuration
-                    self.pool.set_captcha_frequency(freq)
-
-                    # Add quality control rule to the pool
-                    self.pool.quality_control.add_action(
-                        collector=toloka.collectors.Captcha(),
-                        conditions=[toloka.conditions.SuccessRate < success_rate],
-                        action=toloka.actions.RestrictionV2(
-                            scope=toloka.user_restriction.UserRestriction.PROJECT,
-                            duration=duration,
-                            duration_unit=units,
-                            private_comment="Too many Captcha mistakes"
-                        )
-                    )
-
-                    # Print status message
-                    msg.good(f"Added quality control rule: ban for {duration} {units.lower()} if "
-                             f"user's CAPTCHA success rate is less than {success_rate}%. "
-                             f"CAPTCHA frequency is set to {freq}.")
-
                 # Set up GoldenSet quality control (performance on control tasks)
                 if 'golden_set' in self.qual_conf:
 

--- a/tests/data/detect_text.yaml
+++ b/tests/data/detect_text.yaml
@@ -44,8 +44,3 @@ quality_control:
     count: 3
     ban_duration: 7
     ban_units: DAYS
-  captcha:
-    frequency: LOW
-    success_rate: 80
-    ban_duration: 3
-    ban_units: DAYS

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -176,7 +176,6 @@ class TestPool:
 
         # Reconstruct the quality control rules
         qual_control = toloka.quality_control.QualityControl(training_requirement=None,
-                                                             captcha_frequency='LOW',
                                                              configs=[toloka.quality_control.QualityControl.QualityControlConfig(
                                                                  rules=[toloka.quality_control.QualityControl.QualityControlConfig.RuleConfig(
                                                                      action=toloka.actions.RestrictionV2(scope='PROJECT',
@@ -195,15 +194,7 @@ class TestPool:
                                                                                                              private_comment='Skipped assignments'),
                                                                          conditions=[toloka.conditions.SkippedInRowCount(operator=toloka.primitives.operators.CompareOperator('GT'),
                                                                                                                          value=3)])],
-                                                                 collector_config=toloka.collectors.SkippedInRowAssignments()),
-                                                                 toloka.quality_control.QualityControl.QualityControlConfig(
-                                                                     rules=[toloka.quality_control.QualityControl.QualityControlConfig.RuleConfig(
-                                                                         action=toloka.actions.RestrictionV2(scope='PROJECT',
-                                                                                                             duration=3,
-                                                                                                             duration_unit='DAYS',
-                                                                                                             private_comment='Too many Captcha mistakes'),
-                                                                         conditions=[toloka.conditions.SuccessRate(operator=toloka.primitives.operators.CompareOperator('LT'), value=80)])],
-                                                                 collector_config=toloka.collectors.Captcha())],
+                                                                 collector_config=toloka.collectors.SkippedInRowAssignments())],
                                                              checkpoints_config=None
                                                              )
 


### PR DESCRIPTION
Toloka has switched to automatic use of CAPTCHAs. This pull request removes the ability to configure CAPTCHAs manually, as the feature will be deprecated soon.